### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/cisco_duo_ad_sync_failed.yml
+++ b/rules/cisco_duo_ad_sync_failed.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when Cisco Duo Active Directory synchronization fails. This
   can indicate connectivity issues, configuration problems, or potential
   security concerns with the AD integration.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_created.yml
+++ b/rules/cisco_duo_admin_created.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin Created
 description: |-
   Detect when a new administrator account is created in Cisco Duo.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_deleted.yml
+++ b/rules/cisco_duo_admin_deleted.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin Deleted
 description: |-
   Detect when an admin user is deleted from Cisco Duo.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_locked_out_after_too_many_failed_login_attempts.yml
+++ b/rules/cisco_duo_admin_locked_out_after_too_many_failed_login_attempts.yml
@@ -11,7 +11,6 @@ description: |-
   1. Contact the user to determine if they are aware of the failed authentication attempts.
   2. If the user is unaware, investigate the authentication event, focusing on the IP address, application, and user involved.
   3. If the event is deemed malicious, initiate the organization's incident response process to contain the affected account or device.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_marked_push_fraudulent.yml
+++ b/rules/cisco_duo_admin_marked_push_fraudulent.yml
@@ -3,7 +3,6 @@ name: Cisco Duo Admin Marked Push Fraudulent
 description: |-
   Detect when an administrator reports a Duo push authentication
   as fraudulent, which may indicate attempted account compromise.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_mfa_restrictions_updated.yml
+++ b/rules/cisco_duo_admin_mfa_restrictions_updated.yml
@@ -3,7 +3,6 @@ name: Cisco Duo Admin MFA Restrictions Updated
 description: |-
   Detect when MFA restrictions for administrators are modified, which
   may weaken security posture or indicate potential compromise.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_password_reset.yml
+++ b/rules/cisco_duo_admin_password_reset.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin Password Reset
 description: |-
   Detect when an admin password is reset in Cisco Duo.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_sso_saml_requirement_disabled.yml
+++ b/rules/cisco_duo_admin_sso_saml_requirement_disabled.yml
@@ -3,7 +3,6 @@ name: Cisco Duo Admin SSO SAML Requirement Disabled
 description: |-
   Detect when SAML authentication requirements for administrators are
   weakened, which may indicate potential compromise.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_viewed_bypass_code.yml
+++ b/rules/cisco_duo_admin_viewed_bypass_code.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin Viewed Bypass Code
 description: |-
   Detect when an administrator views an MFA bypass code for a user in Cisco Duo.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_admin_viewed_integration_secret_key.yml
+++ b/rules/cisco_duo_admin_viewed_integration_secret_key.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin Viewed App Integration Secret Key
 description: |-
   Detection when an administrator views a secret key for an application integration.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_authentication_policy_updated.yml
+++ b/rules/cisco_duo_authentication_policy_updated.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Authentication Policy Updated
 description: |-
   Detect when authentication policies are modified.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_bypass_code_created_by_administrator.yml
+++ b/rules/cisco_duo_bypass_code_created_by_administrator.yml
@@ -15,7 +15,6 @@ description: |-
      * Disable or review the administrator's account.
      * Reset any affected user accounts associated with the bypass codes.
      * Initiate a security breach investigation.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_bypass_code_is_used_to_authenticate_user_request.yml
+++ b/rules/cisco_duo_bypass_code_is_used_to_authenticate_user_request.yml
@@ -11,7 +11,6 @@ description: |-
   1. Contact the user to confirm they used the bypass code.
   2. If the user is unaware, investigate the authentication event, focusing on the IP address, application, and user involved.
   3. If the event is malicious, initiate your organization's incident response process to contain the affected account or device.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_login_failures_from_different_users.yml
+++ b/rules/cisco_duo_login_failures_from_different_users.yml
@@ -4,7 +4,6 @@ description: |-
   Detect failed login attempts from different users.
   This can indicate potential brute force attacks or
   credential stuffing attempts.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_multiple_users_deleted.yml
+++ b/rules/cisco_duo_multiple_users_deleted.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Multiple Users Deleted
 description: |-
   Detect when multiple users are deleted from Cisco Duo.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_new_admin_api_app_integration.yml
+++ b/rules/cisco_duo_new_admin_api_app_integration.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo New Admin API App Integration
 description: |-
   Detection when a new Admin API integration is created.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_unexpected_auth_factor.yml
+++ b/rules/cisco_duo_unexpected_auth_factor.yml
@@ -4,7 +4,6 @@ description: |-
   Detect when an unexpected authentication factor is used for successful
   authentication. This can indicate potential account compromise or
   unauthorized access methods.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_user_anomalous_push.yml
+++ b/rules/cisco_duo_user_anomalous_push.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo User Auth Denied Due To Anomalous Push
 description: |-
   Detect when authentication is denied due to anomalous push behavior.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_user_endpoint_failure.yml
+++ b/rules/cisco_duo_user_endpoint_failure.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo User Denied For Endpoint Error
 description: |-
   Detect when a Duo user's authentication is denied due endpoint-related errors.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_user_marked_authentication_request_as_fraudulent.yml
+++ b/rules/cisco_duo_user_marked_authentication_request_as_fraudulent.yml
@@ -11,7 +11,6 @@ description: |-
   1. Contact the user to confirm why they found the push suspicious.
   2. Investigate the push event, focusing on the IP address and application involved.
   3. If the event is deemed malicious, initiate your organization's incident response process to contain the affected account or device.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo

--- a/rules/cisco_duo_user_mfa_bypass_enabled.yml
+++ b/rules/cisco_duo_user_mfa_bypass_enabled.yml
@@ -2,7 +2,6 @@
 name: Cisco Duo Admin User MFA Bypass Enabled
 description: |-
   Detect when an administrator enables a user to authentication without MFA.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:cisco_duo


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.